### PR TITLE
Adicionando Validação do CPF e Salvando Endereço no Banco de Dados

### DIFF
--- a/ProjetoFinal/.gitignore
+++ b/ProjetoFinal/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+application.properties

--- a/ProjetoFinal/pom.xml
+++ b/ProjetoFinal/pom.xml
@@ -26,6 +26,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		
+		<dependency>
+		    <groupId>br.com.caelum.stella</groupId>
+		    <artifactId>caelum-stella-core</artifactId>
+		    <version>2.1.2</version>
+		</dependency>
+		<dependency>
+		    <groupId>br.com.caelum.stella</groupId>
+		    <artifactId>caelum-stella-bean-validation</artifactId>
+		    <version>2.1.2</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/ProjetoFinal/src/main/java/org/serratec/dtos/endereco/EnderecoCadastroDTO.java
+++ b/ProjetoFinal/src/main/java/org/serratec/dtos/endereco/EnderecoCadastroDTO.java
@@ -1,6 +1,7 @@
 package org.serratec.dtos.endereco;
 
 import org.serratec.entities.Endereco;
+import org.springframework.web.client.RestTemplate;
 
 public class EnderecoCadastroDTO {
 
@@ -10,10 +11,19 @@ public class EnderecoCadastroDTO {
 	
 	public Endereco toEndereco() {
 		
+		String uri = "https://viacep.com.br/ws/" + cep + "/json/";
+
+	    RestTemplate rest = new RestTemplate();    
+	    EnderecoViaCepDTO viaCep = rest.getForObject(uri, EnderecoViaCepDTO.class);
+		
 		Endereco endereco = new Endereco();
 		endereco.setCep(this.cep);
 		endereco.setComplemento(this.complemento);
 		endereco.setNumero(this.numero);
+		endereco.setRua(viaCep.getLogradouro());
+		endereco.setBairro(viaCep.getBairro());
+		endereco.setCidade(viaCep.getLocalidade());
+		endereco.setEstado(viaCep.getUf());
 		
 		return endereco;
 		

--- a/ProjetoFinal/src/main/java/org/serratec/dtos/endereco/EnderecoCompletoDTO.java
+++ b/ProjetoFinal/src/main/java/org/serratec/dtos/endereco/EnderecoCompletoDTO.java
@@ -1,20 +1,13 @@
 package org.serratec.dtos.endereco;
 
 import org.serratec.entities.Endereco;
-import org.springframework.web.client.RestTemplate;
 
 public class EnderecoCompletoDTO {
 
 	private String completo;
-
+	
 	public EnderecoCompletoDTO(Endereco endereco) {
-		
-		String uri = "https://viacep.com.br/ws/" + endereco.getCep() + "/json/";
-
-	    RestTemplate rest = new RestTemplate();    
-	    EnderecoViaCepDTO viaCep = rest.getForObject(uri, EnderecoViaCepDTO.class);
-	    
-	    this.completo = viaCep.getLogradouro() + ", " + endereco.getNumero() + ", " + endereco.getComplemento() + ", " + viaCep.getBairro() + ", " + viaCep.getLocalidade() + "/" + viaCep.getUf();
+	    this.completo = endereco.getRua() + ", " + endereco.getNumero() + ", " + endereco.getComplemento() + ", " + endereco.getBairro() + ", " + endereco.getCidade() + "/" + endereco.getEstado();
 	}
 
 	public String getCompleto() {

--- a/ProjetoFinal/src/main/java/org/serratec/entities/Client.java
+++ b/ProjetoFinal/src/main/java/org/serratec/entities/Client.java
@@ -10,6 +10,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
+import br.com.caelum.stella.bean.validation.CPF;
+
 @Entity
 public class Client {
 	
@@ -27,6 +29,7 @@ public class Client {
 	private String nome;
 	
 	@Column(unique = true)
+	@CPF
 	private String cpf;
 	
 	private String telefone;

--- a/ProjetoFinal/src/main/java/org/serratec/entities/Pedido.java
+++ b/ProjetoFinal/src/main/java/org/serratec/entities/Pedido.java
@@ -10,7 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
-import org.serratec.entities.enuns.StatusPedido;
+import org.serratec.entities.enums.StatusPedido;
 
 @Entity
 public class Pedido {

--- a/ProjetoFinal/src/main/java/org/serratec/entities/enums/StatusPedido.java
+++ b/ProjetoFinal/src/main/java/org/serratec/entities/enums/StatusPedido.java
@@ -1,4 +1,4 @@
-package org.serratec.entities.enuns;
+package org.serratec.entities.enums;
 
 public enum StatusPedido {
 	

--- a/ProjetoFinal/src/main/java/org/serratec/resources/ClientResource.java
+++ b/ProjetoFinal/src/main/java/org/serratec/resources/ClientResource.java
@@ -45,7 +45,6 @@ public class ClientResource {
 			return new ResponseEntity<>("Cadastro concluído com sucesso!", HttpStatus.OK);
 
 		} catch (DataIntegrityViolationException e) {
-
 			if (repository.existsByEmail(client.getEmail())) {
 				return new ResponseEntity<>("E-mail já cadastrado", HttpStatus.BAD_REQUEST);
 			} else if(repository.existsByUsername(client.getUsername())) {

--- a/ProjetoFinal/src/main/java/org/serratec/resources/ClientResource.java
+++ b/ProjetoFinal/src/main/java/org/serratec/resources/ClientResource.java
@@ -3,6 +3,8 @@ package org.serratec.resources;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.ConstraintViolationException;
+
 import org.serratec.dtos.client.ClientCadastroDTO;
 import org.serratec.dtos.client.ClientCompletoDTO;
 import org.serratec.entities.Client;
@@ -52,6 +54,8 @@ public class ClientResource {
 				return new ResponseEntity<> ("CPF já cadastrado" , HttpStatus.BAD_REQUEST);
 			}
 			return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+		} catch (ConstraintViolationException e) {
+			return new ResponseEntity<> ("Não é um CPF válido" , HttpStatus.BAD_REQUEST);
 		}
 	}
 }


### PR DESCRIPTION
Adicionei a validação do CPF usando o Stella da Caelum. Foram adicionadas as dependências no pom e uma exceção no cliente ressource.
Também modifiquei o pacote de "enuns" para "enums".
Fiz umas modificações no Endereço DTO, agora temos um só para apresentação e um que salva todas as informações no Banco de Dados, tanto as que o usuário passa, quanto as que vem pelo ViaCep.